### PR TITLE
null check extracting boolean exprs from closure

### DIFF
--- a/gcontracts-core/src/main/java/org/gcontracts/util/ExpressionUtils.java
+++ b/gcontracts-core/src/main/java/org/gcontracts/util/ExpressionUtils.java
@@ -78,7 +78,9 @@ public class ExpressionUtils {
                 tmp.setNodeMetaData("statementLabel", stmt.getStatementLabel());
             }
 
-            booleanExpressions.add(tmp);
+            if (tmp != null) {
+                booleanExpressions.add(tmp);
+            }
         }
 
         return booleanExpressions;


### PR DESCRIPTION
If a validation closure contains expression statements, the list of boolean expressions ends up having nulls in it, which then cause NPEs in AssertStatementCreationUtility.getAssertionStatement.
